### PR TITLE
Only set credentials if they exist

### DIFF
--- a/Frends.Community.Email/EmailTask.cs
+++ b/Frends.Community.Email/EmailTask.cs
@@ -85,7 +85,7 @@ namespace Frends.Community.Email
                 Host = settings.SMTPServer
             };
 
-            if (!settings.UseWindowsAuthentication)
+            if (!settings.UseWindowsAuthentication && !string.IsNullOrEmpty(settings.UserName))
                 smtpClient.Credentials = new NetworkCredential(settings.UserName, settings.Password);
 
             return smtpClient;


### PR DESCRIPTION
Improve authentication when Windows Authentication is disabled. See commit comment for details.