### PR TITLE
Fixed issue #15. Only MailKit should be used in EmailTask

### DIFF
--- a/Frends.Community.Email.Tests/SendEmailTests.cs
+++ b/Frends.Community.Email.Tests/SendEmailTests.cs
@@ -16,9 +16,9 @@ namespace Frends.Community.Email.Tests
         private const string SMTPADDRESS = "";
         private const string TOEMAILADDRESS = "";
         private const string FROMEMAILADDRESS = "";
-        private const int PORT = 587;
+        private const int PORT = 465;
         private const bool USESSL = true;
-        private const bool USEWINDOWSAUTHENTICATION = false;
+        private const bool ACCEPTALLCERTS = false;
         // ************************************************************************************************************
 
 
@@ -63,7 +63,7 @@ namespace Frends.Community.Email.Tests
                 SMTPServer = SMTPADDRESS,
                 Port = PORT,
                 UseSsl = USESSL,
-                UseWindowsAuthentication = USEWINDOWSAUTHENTICATION,
+                AcceptAllCerts = ACCEPTALLCERTS
             };
 
         }

--- a/Frends.Community.Email/Definitions.cs
+++ b/Frends.Community.Email/Definitions.cs
@@ -84,16 +84,15 @@ namespace Frends.Community.Email
         public bool UseSsl { get; set; }
 
         /// <summary>
-        /// Set this true if you want to use windows authentication to authenticate to SMTP server.
+        /// Should the task accept all certificates from IMAP server, including invalid ones?
         /// </summary>
-        [DefaultValue("true")]
-        public bool UseWindowsAuthentication { get; set; }
+        [DefaultValue(false)]
+        public bool AcceptAllCerts { get; set; }
 
         /// <summary>
         /// Use this username to log in to the SMTP server
         /// </summary>
         [DefaultValue("\"\"")]
-        [UIHint(nameof(UseWindowsAuthentication), "", false)]
         public string UserName { get; set; }
 
         /// <summary>
@@ -101,7 +100,6 @@ namespace Frends.Community.Email
         /// </summary>
         [PasswordPropertyText(true)]
         [DefaultValue("\"\"")]
-        [UIHint(nameof(UseWindowsAuthentication), "", false)]
         public string Password { get; set; }
     }
 

--- a/Frends.Community.Email/EmailTask.cs
+++ b/Frends.Community.Email/EmailTask.cs
@@ -2,10 +2,13 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Net;
-using System.Net.Mail;
 using System.Threading;
 using System;
 using System.Text;
+using MimeKit;
+using MailKit;
+using MailKit.Net.Smtp;
+using MailKit.Security;
 
 #pragma warning disable 1591
 
@@ -23,115 +26,132 @@ namespace Frends.Community.Email
         {
             var output = new Output();
 
-            using (var client = InitializeSmtpClient(SMTPSettings))
+            var mail = CreateMimeMessage(message);
+
+            if (attachments != null)
             {
-                using (var mail = InitializeMailMessage(message))
+                // email object is created using BodyBuilder
+                var builder = new BodyBuilder();
+
+                if (message.IsMessageHtml)
+                    builder.HtmlBody = string.Format(message.Message);
+                else
+                    builder.TextBody = string.Format(message.Message);
+
+                foreach (var attachment in attachments)
                 {
-                    if (attachments != null)
-                        foreach (var attachment in attachments)
+                    if (attachment.AttachmentType == AttachmentType.FileAttachment)
+                    {
+                        ICollection<string> allAttachmentFilePaths = GetAttachmentFiles(attachment.FilePath);
+
+                        if (attachment.ThrowExceptionIfAttachmentNotFound && allAttachmentFilePaths.Count == 0)
+                            throw new FileNotFoundException(string.Format("The given filepath \"{0}\" had no matching files", attachment.FilePath), attachment.FilePath);
+
+                        if (allAttachmentFilePaths.Count == 0 && !attachment.SendIfNoAttachmentsFound)
                         {
-                            if (attachment.AttachmentType == AttachmentType.FileAttachment)
-                            {
-                                ICollection<string> allAttachmentFilePaths = GetAttachmentFiles(attachment.FilePath);
-
-                                if (attachment.ThrowExceptionIfAttachmentNotFound && allAttachmentFilePaths.Count == 0)
-                                    throw new FileNotFoundException(string.Format("The given filepath \"{0}\" had no matching files", attachment.FilePath), attachment.FilePath);
-
-                                if (allAttachmentFilePaths.Count == 0 && !attachment.SendIfNoAttachmentsFound)
-                                {
-                                    output.StatusString = string.Format("No attachments found matching path \"{0}\". No email sent.", attachment.FilePath);
-                                    output.EmailSent = false;
-                                    return output;
-                                }
-
-                                foreach (var fp in allAttachmentFilePaths)
-                                {
-                                    mail.Attachments.Add(new System.Net.Mail.Attachment(fp));
-                                }
-                            }
-
-                            if (attachment.AttachmentType == AttachmentType.AttachmentFromString)
-                            {
-                                //Create attachment only if content is not empty
-                                if (!string.IsNullOrEmpty(attachment.stringAttachment.FileContent))
-                                    mail.Attachments.Add(System.Net.Mail.Attachment.CreateAttachmentFromString(attachment.stringAttachment.FileContent, attachment.stringAttachment.FileName));
-                            }
-
+                            output.StatusString = string.Format("No attachments found matching path \"{0}\". No email sent.", attachment.FilePath);
+                            output.EmailSent = false;
+                            return output;
                         }
 
-                    cancellationToken.ThrowIfCancellationRequested();
+                        foreach (var filePath in allAttachmentFilePaths)
+                        {
+                            builder.Attachments.Add(filePath);
+                        }
+                    }
 
-                    client.Send(mail);
-
-                    output.EmailSent = true;
-                    output.StatusString = string.Format("Email sent to: {0}", mail.To.ToString());
-
-                    return output;
+                    if (attachment.AttachmentType == AttachmentType.AttachmentFromString)
+                    {
+                        //Create attachment only if content is not empty
+                        if (!string.IsNullOrEmpty(attachment.stringAttachment.FileContent))
+                        {
+                            var path = CreateTemporaryFile(attachment);
+                            builder.Attachments.Add(path);
+                            CleanUpTempWorkDir(path);
+                        }
+                    }
                 }
+
+                mail.Body = builder.ToMessageBody();
             }
-        }
-
-        /// <summary>
-        /// Initializes new SmtpClient with given parameters.
-        /// </summary>
-        private static SmtpClient InitializeSmtpClient(Options settings)
-        {
-            var smtpClient = new SmtpClient
+            else
             {
-                Port = settings.Port,
-                DeliveryMethod = SmtpDeliveryMethod.Network,
-                UseDefaultCredentials = settings.UseWindowsAuthentication,
-                EnableSsl = settings.UseSsl,
-                Host = settings.SMTPServer
-            };
+                mail.Body = (message.IsMessageHtml) 
+                    ? new TextPart(MimeKit.Text.TextFormat.Html) { Text = message.Message } 
+                    : new TextPart(MimeKit.Text.TextFormat.Plain) { Text = message.Message };
+            }
 
-            if (!settings.UseWindowsAuthentication && !string.IsNullOrEmpty(settings.UserName))
-                smtpClient.Credentials = new NetworkCredential(settings.UserName, settings.Password);
+            // Initialize new MailKit SmtpClient
+            using (var client = new SmtpClient())
+            {
+                // Check if UseSsl is enabled and use SslOnConnect if true, else StartTls
+                var secureSocketOption = (SMTPSettings.UseSsl) ? SecureSocketOptions.SslOnConnect : SecureSocketOptions.StartTls;
 
-            return smtpClient;
+                // accept all certs?
+                if (SMTPSettings.AcceptAllCerts)
+                {
+                    client.ServerCertificateValidationCallback = (s, x509certificate, x590chain, sslPolicyErrors) => true;
+                }
+                else
+                {
+                    client.ServerCertificateValidationCallback = MailService.DefaultServerCertificateValidationCallback;
+                }
+
+                client.Connect(SMTPSettings.SMTPServer, SMTPSettings.Port, secureSocketOption);
+                client.AuthenticationMechanisms.Remove("XOAUTH2");
+
+                if (string.IsNullOrEmpty(SMTPSettings.UserName) || string.IsNullOrEmpty(SMTPSettings.Password))
+                    throw new ArgumentException("SMTP credentials were not given for authentication.");
+
+                client.Authenticate(new NetworkCredential(SMTPSettings.UserName, SMTPSettings.Password));
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                client.Send(mail);
+
+                client.Disconnect(true);
+
+                client.Dispose();
+            }
+
+            output.EmailSent = true;
+            output.StatusString = string.Format("Email sent to: {0}", mail.To.ToString());
+
+            return output;
         }
 
         /// <summary>
-        /// Initializes new MailMessage with given parameters. Uses default value 'true' for IsBodyHtml
+        /// Create MimeMessage
         /// </summary>
-        private static MailMessage InitializeMailMessage(Input input)
+        private static MimeMessage CreateMimeMessage([PropertyTab] Input message)
         {
             //split recipients, either by comma or semicolon
             var separators = new[] { ',', ';' };
 
-            string[] recipients = input.To.Split(separators, StringSplitOptions.RemoveEmptyEntries);
-            string[] ccRecipients = input.Cc.Split(separators, StringSplitOptions.RemoveEmptyEntries);
-            string[] bccRecipients = input.Bcc.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            string[] recipients = message.To.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            string[] ccRecipients = message.Cc.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+            string[] bccRecipients = message.Bcc.Split(separators, StringSplitOptions.RemoveEmptyEntries);
 
             //Create mail object
-            var mail = new MailMessage()
-            {
-                From = new MailAddress(input.From, input.SenderName),
-                Subject = input.Subject,
-                Body = input.Message,
-                IsBodyHtml = input.IsMessageHtml
-            };
+            var mail = new MimeMessage();
+            mail.From.Add(new MailboxAddress(message.SenderName, message.From));
+            mail.Subject = message.Subject;
+
             //Add recipients
             foreach (var recipientAddress in recipients)
             {
-                mail.To.Add(recipientAddress);
+                mail.To.Add(MailboxAddress.Parse(recipientAddress));
             }
             //Add CC recipients
             foreach (var ccRecipient in ccRecipients)
             {
-                mail.CC.Add(ccRecipient);
+                mail.Cc.Add(MailboxAddress.Parse(ccRecipient));
             }
             //Add BCC recipients
             foreach (var bccRecipient in bccRecipients)
             {
-                mail.Bcc.Add(bccRecipient);
+                mail.Bcc.Add(MailboxAddress.Parse(bccRecipient));
             }
-
-            //Set message encoding
-            Encoding encoding = Encoding.GetEncoding(input.MessageEncoding);
-
-            mail.BodyEncoding = encoding;
-            mail.SubjectEncoding = encoding;
 
             return mail;
         }
@@ -139,6 +159,7 @@ namespace Frends.Community.Email
         /// <summary>
         /// Gets all actual file names of attachments matching given file path
         /// </summary>
+        /// <param name="filePath"></param>
         private static ICollection<string> GetAttachmentFiles(string filePath)
         {
             string folder = Path.GetDirectoryName(filePath);
@@ -148,5 +169,44 @@ namespace Frends.Community.Email
 
             return filePaths;
         }
+
+        /// <summary>
+        /// Create temp file of attachment from string 
+        /// </summary>
+        /// <param name="attachment"></param>
+        private static string CreateTemporaryFile(Attachment attachment)
+        {
+            var TempWorkDirBase = InitializeTemporaryWorkPath();
+            var filePath = Path.Combine(TempWorkDirBase, attachment.stringAttachment.FileName);
+            var content = attachment.stringAttachment.FileContent;
+
+            using (StreamWriter sw = File.CreateText(filePath))
+            {
+                sw.Write(content);
+            }
+
+            return filePath;
+        }
+
+        /// <summary>
+        /// Remove the temporary workdir
+        /// </summary>
+        /// <param name="tempWorkDir"></param>
+        private static void CleanUpTempWorkDir(string tempWorkDir)
+        {
+            if (!string.IsNullOrEmpty(tempWorkDir) && Directory.Exists(tempWorkDir))
+                Directory.Delete(tempWorkDir, true);
+        }
+
+        /// <summary>
+        /// Create temperary directory for temp file
+        /// </summary>
+        private static string InitializeTemporaryWorkPath()
+        {
+            var tempWorkDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempWorkDir);
+
+            return tempWorkDir;
+        } 
     }
 }

--- a/Frends.Community.Email/Frends.Community.Email.csproj
+++ b/Frends.Community.Email/Frends.Community.Email.csproj
@@ -10,7 +10,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Settings for connecting to SMTP server
 | Smtp server | string | SMTP server address | smtp.somedomain.com |
 | Port | int | SMTP server port | 25 |
 | Use ssl| bool | Set this true if SMTP expects to be connected using SSL | false |
-| Use windows authentication | bool | Set this true if you want to use windows authentication to authenticate to SMTP server | false |
+| AcceptAllCerts |bool |Accept all certificates when connecting the host, if true, will accept event invalid certificates. If false, will accept self-signed certificates if the root is untrusted| false |
 | User name| string | Usable when windows authentication is set false. Use this username to log in to the SMTP server | user |
 | Password | string | Usable when windows authentication is set false. Use this password to log in to the SMTP server | password |
 
@@ -227,4 +227,5 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 2.2.0 | Ported version for linux agent |
 | 2.3.0 | Tighter MAilKit dependency rules |
 | 2.4.0 | Now when Windows Authentication is disabled empty credentials are not set and thus frends Agent's credentials are used. |
+| 2.5.0 | Changed the EmailTask to use only MailKit and replaced System.Net.Mail SmtpClient to MailKit.Net.Smtp SmtpClient. |
 


### PR DESCRIPTION
Fixed issue #15 by changing the EmailTask to use only MailKit.Net.Smtp SmtpClient. Deprecated UseWindowsAuthentication because MailKit doesn't support it. Added AcceptAllCerts option for users that want to enable all certifications on ServerCertificationValidationCallback. Modified the AttachmentFromString to create temp file for the task to use.