### PR TITLE
Made changes to allow to handle multiple emails with same attachment name and to use only app registration to get emails

### DIFF
--- a/Frends.Community.Email/ReadEmailDefinitions.cs
+++ b/Frends.Community.Email/ReadEmailDefinitions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
-namespace Frends.Community.Email
+namespace Frends.Community.Email.ReadEmailDefinition
 {
     /// <summary>
     /// Settings for IMAP and POP3 servers.
@@ -54,25 +54,23 @@ namespace Frends.Community.Email
     /// </summary>
     public class ExchangeSettings
     {
-        /// <summary>
-        /// Email account to use.
-        /// </summary>
-        [DefaultValue("agent@frends.com")]
-        [DisplayFormat(DataFormatString = "Text")]
-        public string Username { get; set; }
-
-        /// <summary>
-        /// Account password.
-        /// </summary>
-        [PasswordPropertyText]
-        public string Password { get; set; }
-
-        /// <summary>
+      /// <summary>
         /// App ID for fetching access token.
         /// </summary>
         [DefaultValue("")]
         public string AppId { get; set; }
+        /// <summary>
+        /// App ID for fetching access token.
+        /// </summary>
+        [PasswordPropertyText]
+        public string AppSecret { get; set; }
 
+        /// <summary>
+        /// Operation scope. Often Microsoft Graph default value is enough. Scopes are delimeted by ;. Example: https://graph.microsoft.com/.default;https://graph.microsoft.com/Mail.Read
+        /// </summary>
+        [DefaultValue("https://graph.microsoft.com/.default")]
+        [DisplayFormat(DataFormatString = "Text")]
+        public string Scopes { get; set; }
         /// <summary>
         /// Tenant ID for fetching access token.
         /// </summary>
@@ -81,15 +79,13 @@ namespace Frends.Community.Email
 
         /// <summary>
         /// Mailbox from where the emails will be read.
-        /// If empty, username will be used.
         /// </summary>
-        [DefaultValue("")]
+        [DefaultValue("groupemailbox@nonfunctionalbox.com")]
         [DisplayFormat(DataFormatString = "Text")]
         public string Mailbox { get; set; }
 
         /// <summary>
-        /// Folder from where the emails will be read.
-        /// If empty then value will be set to Inbox.
+        /// Mailbox from where the emails will be read.
         /// </summary>
         [DefaultValue("Inbox")]
         [DisplayFormat(DataFormatString = "Text")]
@@ -247,9 +243,21 @@ namespace Frends.Community.Email
         /// </summary>
         public string BodyHtml { get; set; }
 
+
         /// <summary>
-        /// Attachment download path.
+        /// List of attachments downloaded List of objects {string OriginalFileName, string SaveDirecrtory, string SaveFilename, string FullPathToSaveFile }
         /// </summary>
-        public List<string> AttachmentSaveDirs { get; set; }
+        public List<Frends.Community.Email.ReadEmailDefinition.Attachment> Attachments { get; set; }
+
+
     }
+
+    public class Attachment
+    {
+        public string OriginalFilename { get; set; }
+        public string SaveDirectory { get; set; }
+        public string SaveFilename { get; set; }
+        public string FullPathToSaveFile { get; set; }
+    }
+
 }

--- a/Frends.Community.Email/ReadEmailDefinitions.cs
+++ b/Frends.Community.Email/ReadEmailDefinitions.cs
@@ -245,7 +245,7 @@ namespace Frends.Community.Email.ReadEmailDefinition
 
 
         /// <summary>
-        /// List of attachments downloaded List of objects {string OriginalFileName, string SaveDirecrtory, string SaveFilename, string FullPathToSaveFile }
+        /// List of attachments downloaded List of objects {string OriginalFileName, string SaveDirectory, string SaveFilename, string FullPathToSaveFile }
         /// </summary>
         public List<Frends.Community.Email.ReadEmailDefinition.Attachment> Attachments { get; set; }
 


### PR DESCRIPTION
Hi,
I made two distinct changes for out needs
1. Only app registration is needed (app id and app secret) to read email boxes (O365) instead of user credentials. This is beause Frends is not a user but an app. This is logical mindset kind of change. Also the app is not referred as "Me" in O365 requests anymore. Now we are using actual emailbox as reference to mailbox.
2. When reading (O365) emails the code did not make it possible to handle multiple emails with attachments having same filename. It stored the attachments with original filename to attachment directory which made it impossible to handle multiple attachments with same filename. Now attachments are saved using unique filenames and object per attachment is returned which contains path to stored file, new filename and original filename. These can now be used to handle files with more control.    