### PR TITLE
ISSUE-31: Removed encoding-parameter from SendEmailToExchange to prevent breaking message content.

### DIFF
--- a/Frends.Community.Email.Tests/ReadExchangeEmailTests.cs
+++ b/Frends.Community.Email.Tests/ReadExchangeEmailTests.cs
@@ -504,7 +504,6 @@ namespace Frends.Community.Email.Tests
                 To = receiver,
                 Message = "This is a test message from Frends.Commmunity.Email Unit Tests.",
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -521,7 +520,6 @@ namespace Frends.Community.Email.Tests
                 To = receiver,
                 Message = "This email has a file attachment.",
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 

--- a/Frends.Community.Email.Tests/SendExchangeEmailTests.cs
+++ b/Frends.Community.Email.Tests/SendExchangeEmailTests.cs
@@ -149,6 +149,28 @@ namespace Frends.Community.Email.Tests
         }
 
         [Test]
+        public async Task SendEmailEncodingTest()
+        {
+            var subject = "Email test - ääööåå";
+            var input = new ExchangeInput
+            {
+                To = _username,
+                Message = "Tämä testimaili tuo yöllä ålannista.",
+                IsMessageHtml = false,
+                MessageEncoding = "utf-8",
+                Subject = subject
+            };
+
+            var result = await EmailTask.SendEmailToExchangeServer(input, null, _server, new CancellationToken());
+            Assert.IsTrue(result.EmailSent);
+            Thread.Sleep(2000); // Give the email some time to get through.
+            var email = await ReadTestEmail(subject);
+            Assert.AreEqual("Tämä testimaili tuo yöllä ålannista.", email[0].BodyText);
+            Assert.AreEqual(subject, email[0].Subject);
+            await DeleteMessages(subject);
+        }
+
+        [Test]
         public async Task SendEmailSwitchEncodingTest()
         {
             var subject = "Email test - ASCII";

--- a/Frends.Community.Email.Tests/SendExchangeEmailTests.cs
+++ b/Frends.Community.Email.Tests/SendExchangeEmailTests.cs
@@ -49,7 +49,6 @@ namespace Frends.Community.Email.Tests
                 To = _username,
                 Message = message,
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -70,7 +69,6 @@ namespace Frends.Community.Email.Tests
                 To = _username + ";" + _username,
                 Message = "This is a test message from Frends.Commmunity.Email Unit Tests.",
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -91,7 +89,6 @@ namespace Frends.Community.Email.Tests
                 To = _username + "," + _username,
                 Message = "This is a test message from Frends.Commmunity.Email Unit Tests.",
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -113,7 +110,6 @@ namespace Frends.Community.Email.Tests
                 Cc = _username,
                 Message = "This is a test message from Frends.Commmunity.Email Unit Tests.",
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -136,7 +132,6 @@ namespace Frends.Community.Email.Tests
                 To = _username,
                 Message = message,
                 IsMessageHtml = true,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -149,7 +144,7 @@ namespace Frends.Community.Email.Tests
         }
 
         [Test]
-        public async Task SendEmailEncodingTest()
+        public async Task SendEmailNordicLettersTest()
         {
             var subject = "Email test - ääööåå";
             var input = new ExchangeInput
@@ -157,7 +152,6 @@ namespace Frends.Community.Email.Tests
                 To = _username,
                 Message = "Tämä testimaili tuo yöllä ålannista.",
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -167,27 +161,6 @@ namespace Frends.Community.Email.Tests
             var email = await ReadTestEmail(subject);
             Assert.AreEqual("Tämä testimaili tuo yöllä ålannista.", email[0].BodyText);
             Assert.AreEqual(subject, email[0].Subject);
-            await DeleteMessages(subject);
-        }
-
-        [Test]
-        public async Task SendEmailSwitchEncodingTest()
-        {
-            var subject = "Email test - ASCII";
-            var input = new ExchangeInput
-            {
-                To = _username,
-                Message = "The letter Ä changes to ?.",
-                IsMessageHtml = false,
-                MessageEncoding = "ascii",
-                Subject = subject
-            };
-
-            var result = await EmailTask.SendEmailToExchangeServer(input, null, _server, new CancellationToken());
-            Assert.IsTrue(result.EmailSent);
-            Thread.Sleep(2000); // Give the email some time to get through.
-            var email = await ReadTestEmail(subject);
-            Assert.AreEqual("The letter ? changes to ?.", email[0].BodyText);
             await DeleteMessages(subject);
         }
 
@@ -202,7 +175,6 @@ namespace Frends.Community.Email.Tests
                 To = _username,
                 Message = "This email has a file attachment.",
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -243,7 +215,6 @@ namespace Frends.Community.Email.Tests
                 To = _username,
                 Message = "This email has a file attachment.",
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -277,7 +248,6 @@ namespace Frends.Community.Email.Tests
                 To = _username,
                 Message = "This email has an attachment written from a string.",
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 
@@ -314,7 +284,6 @@ namespace Frends.Community.Email.Tests
                 To = _username,
                 Message = message,
                 IsMessageHtml = false,
-                MessageEncoding = "utf-8",
                 Subject = subject
             };
 

--- a/Frends.Community.Email/Definitions.cs
+++ b/Frends.Community.Email/Definitions.cs
@@ -101,14 +101,6 @@ namespace Frends.Community.Email
         /// </summary>
         [DefaultValue("false")]
         public bool IsMessageHtml { get; set; }
-
-        /// <summary>
-        /// Encoding of message body and subject.
-        /// Use following table's name column for other options: https://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx#Anchor_5 
-        /// </summary>
-        [DefaultValue("\"utf-8\"")]
-        public string MessageEncoding { get; set; }
-
     }
 
     public class Options

--- a/Frends.Community.Email/EmailTask.cs
+++ b/Frends.Community.Email/EmailTask.cs
@@ -156,7 +156,7 @@ namespace Frends.Community.Email
             var graph = new GraphServiceClient(credentials);
 
             var encoding = GetEncoding(input.MessageEncoding);
-            var bytes = Encoding.Default.GetBytes(input.Message);
+            var bytes = encoding.GetBytes(input.Message);
             var encodedmessage = encoding.GetString(bytes);
 
             var messageBody = new ItemBody

--- a/Frends.Community.Email/EmailTask.cs
+++ b/Frends.Community.Email/EmailTask.cs
@@ -155,14 +155,10 @@ namespace Frends.Community.Email
             var credentials = new UsernamePasswordCredential(settings.Username, settings.Password, settings.TenantId, settings.AppId, options);
             var graph = new GraphServiceClient(credentials);
 
-            var encoding = GetEncoding(input.MessageEncoding);
-            var bytes = encoding.GetBytes(input.Message);
-            var encodedmessage = encoding.GetString(bytes);
-
             var messageBody = new ItemBody
             {
                 ContentType = input.IsMessageHtml ? BodyType.Html : BodyType.Text,
-                Content = encodedmessage
+                Content = input.Message
             };
 
             var recipients = input.To.Split(new char[] { ',', ';'}, StringSplitOptions.RemoveEmptyEntries);

--- a/Frends.Community.Email/Frends.Community.Email.csproj
+++ b/Frends.Community.Email/Frends.Community.Email.csproj
@@ -10,7 +10,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.3</Version>
+    <Version>4.0.0</Version>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
   </PropertyGroup>
 

--- a/Frends.Community.Email/Frends.Community.Email.csproj
+++ b/Frends.Community.Email/Frends.Community.Email.csproj
@@ -10,7 +10,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.2</Version>
+    <Version>3.2.3</Version>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -306,4 +306,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 3.2.0   | ReadEmailFromExchangeServer: Fixed issue where attachments are saved even if the email is not read. Added option to select what should be done if the attachment file exists in destination directory. |
 | 3.2.1   | ReadEmailFromExchangeServer: Fixed issue where user was not able to read attachments from other users mailbox.                                            |
 | 3.2.2   | SendEmailToExchangeServer: Enabled sending bigger files than 3MB as an attachments.                                                                       |
-| 3.2.3   | SendEmailToExchangeServer: Fixed issue with message encoding.                                                                                             |
+| 4.0.0   | SendEmailToExchangeServer: Removed encoding-parameter to prevent braking message content.                                                                 |

--- a/README.md
+++ b/README.md
@@ -306,3 +306,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 3.2.0   | ReadEmailFromExchangeServer: Fixed issue where attachments are saved even if the email is not read. Added option to select what should be done if the attachment file exists in destination directory. |
 | 3.2.1   | ReadEmailFromExchangeServer: Fixed issue where user was not able to read attachments from other users mailbox.                                            |
 | 3.2.2   | SendEmailToExchangeServer: Enabled sending bigger files than 3MB as an attachments.                                                                       |
+| 3.2.3   | SendEmailToExchangeServer: Fixed issue with message encoding.                                                                                             |


### PR DESCRIPTION
Fixes #31 